### PR TITLE
Handle Oculus DH compat when addon present

### DIFF
--- a/src/main/java/net/Gabou/oculus_for_simpleclouds/mixin/SimpleCloudsCompatHelperMixin.java
+++ b/src/main/java/net/Gabou/oculus_for_simpleclouds/mixin/SimpleCloudsCompatHelperMixin.java
@@ -1,0 +1,22 @@
+package net.Gabou.oculus_for_simpleclouds.mixin;
+
+import dev.nonamecrackers2.simpleclouds.SimpleCloudsMod;
+import dev.nonamecrackers2.simpleclouds.client.compat.SimpleCloudsCompatHelper;
+import net.minecraftforge.fml.ModList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(SimpleCloudsCompatHelper.class)
+public class SimpleCloudsCompatHelperMixin {
+    @Redirect(
+            method = "findCompatErrors",
+            at = @At(value = "INVOKE", target = "Ldev/nonamecrackers2/simpleclouds/SimpleCloudsMod;dhLoaded()Z")
+    )
+    private static boolean oculus_for_simpleclouds$skipOculusDhErrorWhenAddonLoaded() {
+        if (ModList.get().isLoaded("simplecloudsoculus")) {
+            return false;
+        }
+        return SimpleCloudsMod.dhLoaded();
+    }
+}

--- a/src/main/resources/oculus_for_simpleclouds.mixins.json
+++ b/src/main/resources/oculus_for_simpleclouds.mixins.json
@@ -7,6 +7,7 @@
   "mixins": [
   ],
   "client": [
+    "SimpleCloudsCompatHelperMixin",
     "ShaderPropertiesMixin",
     "ExtendedShaderMixin"
   ],


### PR DESCRIPTION
## Summary
- add mixin to guard SimpleClouds Oculus/Distant Horizons compat error when the SimpleClouds Oculus addon is installed
- register the new mixin in the client mixin configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0ae08464833199910344ec3e38f0)