### PR TITLE
Handle DH depth format during capture

### DIFF
--- a/src/main/java/net/Gabou/oculus_for_simpleclouds/dh/ShaderAwareDhPipeline.java
+++ b/src/main/java/net/Gabou/oculus_for_simpleclouds/dh/ShaderAwareDhPipeline.java
@@ -118,7 +118,9 @@ public class ShaderAwareDhPipeline implements CloudsRenderPipeline, ShaderAwareD
         transparencyTarget.clear(Minecraft.ON_OSX);
         RenderTarget mainTarget = mc.getMainRenderTarget();
         // Capture vanilla depth now (pre-shader) for final composite occlusion.
+        FinalCloudCompositeHandler.beginDistantHorizonsDepthAccess(dhFbo);
         FinalCloudCompositeHandler.captureDepth(mainTarget);
+        FinalCloudCompositeHandler.endDistantHorizonsDepthAccess();
         boolean reverseDepth = isReverseDepthEnabled();
         boolean copiedVanillaDepth = copyVanillaDepthToCloudTarget(cloudTarget, mainTarget);
         int dhDepthTex = resolveDepthTextureId(dhFbo);


### PR DESCRIPTION
## Summary
- align the captured depth texture format with the active Minecraft or Distant Horizons depth attachment before blitting
- track Distant Horizons depth access and log depth formats for debugging
- ensure DH-aware pipeline brackets depth capture with the new context hooks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692876b9a3008331b2c55e4a4cba92e0)